### PR TITLE
Fix for: Third party pack cannot be found likely because the corresponding app is restricted

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ android {
 }
 ```
 
+Add the following option to your AndroidManifest.xml file, or you will get error like: whatsapp not installed, when you send to pack
+
+```
+<queries>
+    <package android:name="com.whatsapp" />
+    <package android:name="com.whatsapp.w4b" />
+</queries>
+```
+
 ### iOS
 
 Do not forget to add following entry to ```Info.plist``` with ```Runner``` target.

--- a/android/src/main/kotlin/dev/applicazza/flutter/plugins/whatsapp_stickers_plus/StickerContentProvider.java
+++ b/android/src/main/kotlin/dev/applicazza/flutter/plugins/whatsapp_stickers_plus/StickerContentProvider.java
@@ -173,9 +173,14 @@ public class StickerContentProvider extends ContentProvider {
     }
 
     private List<StickerPack> getStickerPackList() {
-        if (stickerPackList == null) {
+        // This check causes this error:
+        // Third party pack cannot be found likely because the corresponding app is restricted
+        // when try to add a sticker pack after successfully adding a sticker pack.
+        // For details, see
+        // https://github.com/WhatsApp/stickers/issues/584
+        // if (stickerPackList == null) {
             readContentFile(Objects.requireNonNull(getContext()));
-        }
+        // }
         return stickerPackList;
     }
 


### PR DESCRIPTION
Ref:
https://github.com/WhatsApp/stickers/issues/584#issuecomment-629464558

And some meta data for Android